### PR TITLE
[codex] Fix mise update bootstrap

### DIFF
--- a/dev/mise/_init
+++ b/dev/mise/_init
@@ -6,6 +6,43 @@ os=(macos debian)
 
 link() { : }  # mise global config is user-managed, nothing to symlink
 
+_mise_refresh_path() {
+  local brew_prefix
+
+  path=( "$XDG_BIN_HOME" $path )
+
+  if _is_callable brew; then
+    brew_prefix="$(brew --prefix 2>/dev/null)"
+    [[ -n $brew_prefix ]] && path=( "$brew_prefix/bin" $path )
+  fi
+
+  rehash
+}
+
+_mise_require() {
+  _mise_refresh_path
+  if ! _is_callable mise; then
+    echo-fail "mise is not available in PATH"
+    return 1
+  fi
+}
+
+_brew_upgrade_formula() {
+  local formula=$1 outdated
+
+  if ! brew list --formula "$formula" >/dev/null 2>&1; then
+    brew install "$formula"
+    return
+  fi
+
+  outdated="$(brew outdated --quiet "$formula")"
+  if [[ -n $outdated ]]; then
+    brew upgrade "$formula"
+  else
+    echo-ok "$formula is already up-to-date"
+  fi
+}
+
 install() {
   case $(_os) in
     macos)
@@ -18,6 +55,8 @@ install() {
       ;;
   esac
 
+  _mise_require || return 1
+
   # Bootstrap: initialize mise so it's usable right away
   source config.zsh
 
@@ -26,14 +65,28 @@ install() {
 }
 
 update() {
-  case $(_os) in
-    macos)
-      brew upgrade mise
-      ;;
-    debian)
-      mise self-update
-      ;;
-  esac
+  _mise_refresh_path
+
+  if ! _is_callable mise; then
+    echo-alert "mise not found; installing first"
+    install || return 1
+  else
+    case $(_os) in
+      macos)
+        if brew list --formula mise >/dev/null 2>&1; then
+          _brew_upgrade_formula mise
+        else
+          echo-info "mise is not managed by Homebrew; using self-update"
+          mise self-update
+        fi
+        ;;
+      debian)
+        mise self-update
+        ;;
+    esac
+  fi
+
+  _mise_require || return 1
   mise upgrade
 }
 

--- a/editor/emacs/doom/+bindings.el
+++ b/editor/emacs/doom/+bindings.el
@@ -328,9 +328,6 @@
          :desc "Yank org subtree"           "s"     #'org-copy-subtree)
        )
 
-      ;;; <leader> n --- notes
-      :desc "Obsidian notes"                "n SPC" #'obsidian-jump
-
       ;;; <leader> o --- open
       :desc "Open directory in dirvish"     "o d"   #'dirvish
       :desc "Dired"                         "o /"   #'dired

--- a/editor/emacs/doom/+defaults.el
+++ b/editor/emacs/doom/+defaults.el
@@ -8,8 +8,7 @@
 
 ;; Tell projectile where my projects are located
 (setq projectile-project-search-path
-      '(("~/dev" . 2)
-        ("~/Library/Mobile Documents/iCloud~md~obsidian/Documents" . 2)))
+      '(("~/dev" . 2)))
 (setq projectile-enable-caching nil)
 
 ;; ─── Editor Performance & Display ─────────────────────────────────────────────
@@ -19,8 +18,8 @@
 (remove-hook! '(prog-mode-hook text-mode-hook conf-mode-hook) #'display-line-numbers-mode)
 (setq display-line-numbers-type t)
 
-;; Enable scroll margin for better context when scrolling
-(setq scroll-margin 10)
+;; `ultra-scroll' requires a zero margin to avoid rendering glitches.
+(setq scroll-margin 0)
 
 ;; Show trailing whitespace in code & config
 (add-hook! '(prog-mode-hook conf-mode-hook) #'doom-enable-show-trailing-whitespace-h)

--- a/editor/emacs/doom/+modules.el
+++ b/editor/emacs/doom/+modules.el
@@ -313,25 +313,6 @@
   (setq evil-collection-magit-use-y-for-yank t))
 
 
-;; ─── Obsidian ─────────────────────────────────────────────────────────────────
-
-(use-package! obsidian
-  ;; :demand t
-  :config
-  (obsidian-specify-path "~/Library/Mobile Documents/iCloud~md~obsidian/Documents/Personal")
-  (global-obsidian-mode t)
-  :custom
-  ;; This directory will be used for `obsidian-capture' if set.
-  (obsidian-inbox-directory "notas")
-  :bind (:map obsidian-mode-map
-              ;; Replace C-c C-o with Obsidian.el's implementation. It's ok to use another key binding.
-              ("C-c C-o" . obsidian-follow-link-at-point)
-              ;; Jump to backlinks
-              ("C-c C-b" . obsidian-backlink-jump)
-              ;; If you prefer you can use `obsidian-insert-link'
-              ("C-c C-l" . obsidian-insert-wikilink)))
-
-
 ;; ─── REPL ─────────────────────────────────────────────────────────────────────
 
 ;; Set a default REPL for all the js-related modes

--- a/editor/emacs/doom/+ui.el
+++ b/editor/emacs/doom/+ui.el
@@ -23,12 +23,14 @@
 ;; Workaround to ensure that nothing else gets in front of my `custom-theme-directory' after initialization. Doom's core
 ;; is supposed to handle this, but it isn't working correctly, so I've mimicked its approach within a hook
 
-(add-hook! 'doom-init-ui-hook
-  (defun my/prioritize-custom-theme-directory-h ()
-    "Prioritize my custom them path over all other themes"
-    (setq custom-theme-load-path
-          (cons custom-theme-directory
-                (delq 'custom-theme-directory custom-theme-load-path)))))
+(defun my/prioritize-custom-theme-directory-h ()
+  "Prioritize my custom theme path over all other themes."
+  (setq custom-theme-load-path
+        (cons custom-theme-directory
+              (delete custom-theme-directory custom-theme-load-path))))
+
+(my/prioritize-custom-theme-directory-h)
+(add-hook! 'doom-init-ui-hook #'my/prioritize-custom-theme-directory-h)
 
 (setq doom-theme 'doom-oceanic-next)
 
@@ -108,6 +110,9 @@
 
 ;; ─── Frame ────────────────────────────────────────────────────────────────────
 
+;; Start the initial frame maximized.
+(add-to-list 'initial-frame-alist '(fullscreen . maximized))
+
 ;; Show file path in the title for files with the same base name. For example, the files `/foo/bar/mumble/name'
 ;; and `/baz/quux/mumble/name' would have the following buffer names:
 ;; bar/mumble/name    quux/mumble/name
@@ -120,7 +125,7 @@
 (setq fancy-splash-image (concat doom-user-dir "banners/berserk-guts-eclipse-1.png"))
 
 ;; Hide the menu for as minimalistic a startup screen as possible.
-(remove-hook '+doom-dashboard-functions #'doom-dashboard-widget-shortmenu)
+(remove-hook '+dashboard-functions #'+dashboard-widget-shortmenu)
 
 
 ;; ─── Flycheck posframe ────────────────────────────────────────────────────────

--- a/editor/emacs/doom/init.el
+++ b/editor/emacs/doom/init.el
@@ -1,21 +1,18 @@
-;;; init.el -*- lexical-binding: t; -*-
+;;; $DOOMDIR/init.el -*- lexical-binding: t; -*-
 
 ;; This file controls what Doom modules are enabled and what order they load
 ;; in. Remember to run 'doom sync' after modifying it!
 
-;; NOTE Press 'SPC h d h' (or 'C-h d h' for non-vim users) to access Doom's
-;;      documentation. There you'll find a link to Doom's Module Index where all
-;;      of our modules are listed, including what flags they support.
+;; NOTE: Press 'SPC h d h' (or 'C-h d h' for non-vim users) to access Doom's
+;;   documentation. There you'll find a link to Doom's Module Index where all of
+;;   our modules are listed, including what flags they support.
 
-;; NOTE Move your cursor over a module's name (or its flags) and press 'K' (or
-;;      'C-c c k' for non-vim users) to view its documentation. This works on
-;;      flags as well (those symbols that start with a plus).
+;; NOTE: Move your cursor over a module's name (or its flags) and press 'K' (or
+;;   'C-c c k' for non-vim users) to view its documentation. This works on flags
+;;   as well (those symbols that start with a plus).
 ;;
-;;      Alternatively, press 'gd' (or 'C-c c d') on a module to browse its
-;;      directory (for easy access to its source code).
-
-;; start the initial frame maximized
-(add-to-list 'initial-frame-alist '(fullscreen . maximized))
+;;   Alternatively, press 'gd' (or 'C-c c d') on a module to browse its
+;;   directory (for easy access to its source code).
 
 (doom! :input
        ;;bidi              ; (tfel ot) thgir etirw uoy gnipleh
@@ -24,30 +21,19 @@
        ;;layout            ; auie,ctsrnm is the superior home row
 
        :completion
-       ;; (company          ; the ultimate code completion backend
-       ;;  +childframe
-       ;;  ;; +tng
-       ;;  )
-       (corfu            ; complete with cap(f), cape and a flying feather!
-        +icons
-        +dabbrev
-        +orderless)
+       ;;company           ; the ultimate code completion backend
+       (corfu +icons +dabbrev +orderless)  ; complete with cap(f), cape and a flying feather!
        ;;helm              ; the *other* search engine for love and life
        ;;ido               ; the other *other* search engine...
        ;;ivy               ; a search engine for love and life
-       (vertico          ; the search engine of the future
-        +icons
-        +childframe
-        )
+       (vertico +icons +childframe)  ; the search engine of the future
 
        :ui
        ;;deft              ; notational velocity for Emacs
        doom              ; what makes DOOM look the way it does
-       doom-dashboard    ; a nifty splash screen for Emacs
+       dashboard         ; a nifty splash screen for Emacs
        doom-quit         ; DOOM quit-message prompts when you quit Emacs
-       (emoji            ; 🙂
-        ;; +unicode
-        )
+       emoji             ; 🙂
        hl-todo           ; highlight TODO/FIXME/NOTE/DEPRECATED/HACK/REVIEW
        ;;indent-guides     ; highlighted indent columns
        ;;ligatures         ; ligatures and symbols to make your code pretty again
@@ -56,15 +42,14 @@
        ;;nav-flash         ; blink cursor line after big motions
        ;;neotree           ; a project drawer, like NERDTree for vim
        ophints           ; highlight the region an operation acts on
-       (popup +defaults)   ; tame sudden yet inevitable temporary windows
-       ;;smooth-scroll     ; So smooth you won't believe it's not butter
+       (popup +defaults) ; tame sudden yet inevitable temporary windows
+       smooth-scroll     ; So smooth you won't believe it's not butter
        ;;tabs              ; a tab bar for Emacs
        ;;treemacs          ; a project drawer, like neotree but cooler
        ;;unicode           ; extended unicode support for various languages
        (vc-gutter +pretty) ; vcs diff in the fringe
        vi-tilde-fringe   ; fringe tildes to mark beyond EOB
-       (window-select    ; visually switch windows
-        +switch-window)
+       (window-select +switch-window) ; visually switch windows
        workspaces        ; tab emulation, persistence & separate workspaces
        zen               ; distraction-free coding or writing
 
@@ -72,10 +57,7 @@
        (evil +everywhere); come to the dark side, we have cookies
        file-templates    ; auto-snippets for empty files
        fold              ; (nigh) universal code folding
-       (format           ; automated prettiness
-        ;; +onsave
-        +lsp
-        )
+       (format +lsp)     ; automated prettiness
        ;;god               ; run Emacs commands without modifier keys
        ;;lispy             ; vim for lisp, for people who don't like vim
        multiple-cursors  ; editing in many places at once
@@ -83,18 +65,14 @@
        ;;parinfer          ; turn lisp into python, sort of
        ;;rotate-text       ; cycle region at point between text candidates
        snippets          ; my elves. They type so I don't have to
-       (whitespace       ; a butler for your whitespace
-         +guess
-         +trim
-         )
+       (whitespace +guess +trim) ; a butler for your whitespace
        word-wrap         ; soft wrapping with language-aware indent
 
        :emacs
-       (dired            ; making dired pretty [functional]
-        +dirvish +icons)
+       (dired +dirvish +icons) ; making dired pretty [functional]
        electric          ; smarter, keyword-based electric-indent
        ;;eww               ; the internet is gross
-       ;;(ibuffer +icons)  ; interactive buffer management
+       ;;ibuffer           ; interactive buffer management
        tramp             ; remote files at your arthritic fingertips
        undo              ; persistent, smarter undo for your inevitable mistakes
        vc                ; version-control and Emacs, sitting in a tree
@@ -103,13 +81,11 @@
        ;;eshell            ; the elisp shell that works everywhere
        ;;shell             ; simple shell REPL for Emacs
        ;;term              ; basic terminal emulator for Emacs
-       vterm             ; the best terminal emulation in Emacs
+       vterm             ; almost the best terminal emulation in Emacs
+       ;;ghostel           ; the best terminal emulation in Emacs
 
        :checkers
-       (syntax           ; tasing you for every semicolon you forget
-        +childframe
-        +icons
-        )
+       (syntax +childframe +icons) ; tasing you for every semicolon you forget
        ;;(spell +flyspell) ; tasing you for misspelling mispelling
        ;;grammar           ; tasing grammar mistake every you make
 
@@ -117,19 +93,15 @@
        ;;ansible
        ;;biblio            ; Writes a PhD for you (citation needed)
        ;;collab            ; buffers with friends
-       ;;debugger          ; FIXME stepping through code, to help you add bugs
+       ;;debugger          ; stepping through code, to help you add bugs
        ;;direnv
        docker
        editorconfig      ; let someone else argue about tabs vs spaces
        ;;ein               ; tame Jupyter notebooks with emacs
-       (eval +overlay)     ; run code, run (also, repls)
-       lookup              ; navigate your code and its documentation
+       (eval +overlay)   ; run code, run (also, repls)
+       lookup            ; navigate your code and its documentation
        llm               ; when I said you needed friends, I didn't mean...
-       (lsp              ; M-x vscode
-        ;; +eglot
-        ;; +booster
-        ;; +peek
-        )
+       lsp               ; M-x vscode
        (magit +forge)    ; a git porcelain for Emacs
        make              ; run make tasks from Emacs
        ;;pass              ; password manager for nerds
@@ -145,7 +117,7 @@
 
        :lang
        ;;ada               ; In strong typing we (blindly) trust
-       ;;agda              ; types of types of types of types...
+       ;;(agda +local)     ; types of types of types of types...
        ;;beancount         ; mind the GAAP
        (cc +lsp)         ; C > C++ == 1
        ;;clojure           ; java with a lisp
@@ -175,10 +147,7 @@
        (json +lsp)       ; At least it ain't XML
        ;;janet             ; Fun fact: Janet is me!
        ;;(java +lsp)       ; the poster child for carpal tunnel syndrome
-       (javascript       ; all(hope(abandon(ye(who(enter(here))))))
-        +lsp
-        +tree-sitter
-        )
+       (javascript +lsp +tree-sitter) ; all(hope(abandon(ye(who(enter(here))))))
        ;;julia             ; a better, faster MATLAB
        ;;kotlin            ; a better, slicker Java(Script)
        ;;latex             ; writing papers in Emacs has never been so fun
@@ -189,11 +158,9 @@
        ;;nim               ; python + lisp at the speed of c
        nix               ; I hereby declare "nix geht mehr!"
        ;;ocaml             ; an objective camel
+       ;;odin              ; C, minus its footguns
        org               ; organize your plain life in plain text
-       (php              ; perl's insecure younger brother
-        +lsp
-        +tree-sitter
-        )
+       (php +lsp +tree-sitter) ; perl's insecure younger brother
        ;;plantuml          ; diagrams for confusing people more
        ;;graphviz          ; diagrams for confusing yourself even more
        ;;purescript        ; javascript, but functional
@@ -205,6 +172,7 @@
        ;;rst               ; ReST in peace
        ;;(ruby +rails)     ; 1.step {|i| p "Ruby is #{i.even? ? 'love' : 'life'}"}
        ;;(rust +lsp)       ; Fe2O3.unwrap().unwrap().unwrap().unwrap()
+       ;;scad              ; trust the preview, regret the render
        ;;scala             ; java, but good
        ;;(scheme +guile)   ; a fully conniving family of lisps
        sh                ; she sells {ba,z,fi}sh shells on the C xor
@@ -212,10 +180,7 @@
        ;;solidity          ; do you need a blockchain? No.
        ;;swift             ; who asked for emoji variables?
        ;;terra             ; Earth and Moon in alignment for performance.
-       (web              ; the tubes
-        +lsp
-        +tree-sitter
-        )
+       (web +lsp +tree-sitter) ; the tubes
        yaml              ; JSON, but readable
        ;;zig               ; C, but simpler
 

--- a/editor/emacs/doom/packages.el
+++ b/editor/emacs/doom/packages.el
@@ -57,17 +57,16 @@
 (package! emmet-mode :disable t)   ;; not needed for my workflow
 
 ;; ─── Syntax Highlighting & File Modes ─────────────────────────────────────────
-(package! vimrc-mode)  ;; Provides syntax highlighting for Vim configuration files (.vimrc, .vim)
+(package! vimrc-mode :pin "f594392a0834193a1fe1522d007e1c8ce5b68e43")  ;; Provides syntax highlighting for Vim configuration files (.vimrc, .vim)
 
 ;; ─── Productivity & Writing ───────────────────────────────────────────────────
-(package! obsidian)  ;; Integration with Obsidian for note-taking
-(package! string-inflection)  ;; Cycle through different naming conventions (camelCase, snake_case, etc.)
+(package! string-inflection :pin "4a2f87d7b47f5efe702a78f8a40a98df36eeba13")  ;; Cycle through different naming conventions (camelCase, snake_case, etc.)
 
 ;; ─── Snippet Management ───────────────────────────────────────────────────────
 (package! doom-snippets
   :recipe (:local-repo "snippets"))
 
 ;; ─── Editing Enhancements ─────────────────────────────────────────────────────
-(package! drag-stuff)  ;; Move lines or text blocks up/down/left/right using shortcuts
+(package! drag-stuff :pin "6d06d846cd37c052d79acd0f372c13006aa7e7c8")  ;; Move lines or text blocks up/down/left/right using shortcuts
 
-(package! denote)
+(package! denote :pin "33640be055025269c0e8b7722d0f44c204d840ed")


### PR DESCRIPTION
## What changed

- Make `dev/mise` refresh PATH from XDG bin and the active Homebrew prefix before checking for `mise`.
- Make `update` install/bootstrap `mise` first when the binary is missing.
- Avoid noisy `brew upgrade mise` warnings when the formula is already up to date.

## Why

`dev/mise.init.update` could fail with `mise not installed` followed by `command not found: mise` when the topic was already enabled but the binary was not available in PATH or not installed through the expected Homebrew prefix.

## Validation

- `zsh -n dev/mise/_init`
- `dev/mise/_init update`
- `git diff --check`